### PR TITLE
Eliminate need for nightly Rust

### DIFF
--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 use std::io;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{self, Poll};
@@ -75,18 +75,43 @@ impl Service<hyper_dns::Name> for TrustDnsResolver {
 
             let lookup = resolver.lookup_ip(name.as_str()).await?;
 
-            let iter = lookup.into_iter().filter_map(|ip| {
-                if ip.is_global() {
-                    Some(SocketAddr::new(ip, 0))
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>()
-            .into_iter();
+            let iter = lookup
+                .into_iter()
+                .filter_map(|ip| {
+                    if is_allowed(ip) {
+                        Some(SocketAddr::new(ip, 0))
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+                .into_iter();
 
             Ok(iter)
         })
+    }
+}
+
+fn is_allowed(addr: IpAddr) -> bool {
+    match addr {
+        IpAddr::V4(addr) => {
+            !addr.is_loopback()
+                && !addr.is_link_local()
+                && !addr.is_broadcast()
+                && !addr.is_documentation()
+                && !is_shared(addr)
+                && !is_reserved(addr)
+                && !is_benchmarking(addr)
+                && !starts_with_zero(addr)
+        }
+        IpAddr::V6(addr) => {
+            !addr.is_multicast()
+                && !addr.is_loopback()
+                && !is_unicast_link_local(addr)
+                && !is_unique_local(addr)
+                && !addr.is_unspecified()
+                && !is_documentation_v6(addr)
+        }
     }
 }
 
@@ -97,4 +122,34 @@ async fn new_resolver() -> Result<SharedResolver, BoxError> {
         .clone();
     let resolver = AsyncResolver::new(config, opts, TokioHandle)?;
     Ok(Arc::new(resolver))
+}
+
+/// Util functions copied from the unstable standard library near identically
+fn is_shared(addr: Ipv4Addr) -> bool {
+    addr.octets()[0] == 100 && (addr.octets()[1] & 0b1100_0000 == 0b0100_0000)
+}
+
+fn is_reserved(addr: Ipv4Addr) -> bool {
+    (addr.octets()[0] == 192 && addr.octets()[1] == 0 && addr.octets()[2] == 0)
+        || (addr.octets()[0] & 240 == 240 && !addr.is_broadcast())
+}
+
+fn is_benchmarking(addr: Ipv4Addr) -> bool {
+    addr.octets()[0] == 198 && (addr.octets()[1] & 0xfe) == 18
+}
+
+fn starts_with_zero(addr: Ipv4Addr) -> bool {
+    addr.octets()[0] == 0
+}
+
+fn is_unicast_link_local(addr: Ipv6Addr) -> bool {
+    (addr.segments()[0] & 0xffc0) == 0xfe80
+}
+
+fn is_unique_local(addr: Ipv6Addr) -> bool {
+    (addr.segments()[0] & 0xfe00) == 0xfc00
+}
+
+fn is_documentation_v6(addr: Ipv6Addr) -> bool {
+    (addr.segments()[0] == 0x2001) && (addr.segments()[1] == 0xdb8)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, deny(warnings))]
 #![doc(html_root_url = "https://docs.rs/reqwest/0.11.12")]
-#![feature(ip)]
 
 //! # reqwest
 //!


### PR DESCRIPTION
Replicates `IpAddr` utilities from the Rust standard library to avoid reliance on Rust nightly.